### PR TITLE
better styles for buttons

### DIFF
--- a/src/renderer/components/appBar/appBar.scss
+++ b/src/renderer/components/appBar/appBar.scss
@@ -19,3 +19,27 @@
     display: contents;
   }
 }
+
+@media (max-width: 1000px) {
+  .button {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 800px) {
+  .button {
+    font-size: 10px;
+  }
+}
+
+@media (max-width: 660px) {
+  .button {
+    font-size: 8px;
+  }
+}
+
+@media (max-width: 400px) {
+  .button {
+    font-size: 6px;
+  }
+}


### PR DESCRIPTION
basic styling for buttons. make them appear on smaller devices

<img width="788" alt="Service_Locator" src="https://user-images.githubusercontent.com/2163914/58060444-7950b800-7b3f-11e9-9421-817e6ed038f1.png">
<img width="783" alt="Service_Locator" src="https://user-images.githubusercontent.com/2163914/58060454-879ed400-7b3f-11e9-8916-dc4640084565.png">
