### PR TITLE
add way to report inactive locations

### DIFF
--- a/src/renderer/containers/map/infoBox/index.jsx
+++ b/src/renderer/containers/map/infoBox/index.jsx
@@ -33,6 +33,7 @@ export default class InfoBox extends React.Component {
       details.address1
     )}+${details.zipCode}`;
     const email = {
+      cc: 'columbushelper+inactiveLocation@gmail.com',
       to: 'smartcolumbusos@columbus.gov',
       subject: 'Service Location No Longer Active',
       body: `The following service area is no longer active.\n\n\t${
@@ -85,7 +86,7 @@ export default class InfoBox extends React.Component {
               className="mail"
               href={`https://mail.google.com/mail/?view=cm&fs=1&tf=1&to=${
                 email.to
-              }&su=${email.subject}&body=${encodeURIComponent(email.body)}`}
+              }&cc=${encodeURIComponent(email.cc)}&su=${email.subject}&body=${encodeURIComponent(email.body)}`}
               target="_blank"
               rel="noopener noreferrer">
               Report Inactive

--- a/src/renderer/containers/map/infoBox/index.jsx
+++ b/src/renderer/containers/map/infoBox/index.jsx
@@ -40,7 +40,7 @@ export default class InfoBox extends React.Component {
         details.name
       }\n\t${details.address1}\n\t${details.address2}\n\tPhone: ${
         details.areaCode
-      }${details.phoneNumber}`,
+      }${details.phoneNumber}\n\nDataset: https://discovery.smartcolumbusos.com/dataset/handson_central_ohio/570a8e02_fb0e_4cee_895b_3b32bd740650`,
     };
     return (
       <div className="info-box">

--- a/src/renderer/containers/map/infoBox/index.jsx
+++ b/src/renderer/containers/map/infoBox/index.jsx
@@ -32,13 +32,20 @@ export default class InfoBox extends React.Component {
     const address = `https://www.google.com/maps/place/${conversion(
       details.address1
     )}+${details.zipCode}`;
+    const email = {
+      to: 'smartcolumbusos@columbus.gov',
+      subject: 'Service location No Longer Active',
+      body: `The following service area is no longer active.\n\n\t${
+        details.name
+      }\n\t${details.address1}\n\t${details.address2}\n\tPhone: ${
+        details.areaCode
+      }${details.phoneNumber}`,
+    };
     return (
       <div className="info-box">
         <div className="content">
           <h2>{details.name}</h2>
-           <a
-            href={address}
-            className="address" target="_blank">
+          <a href={address} className="address" target="_blank">
             {details.address1}
             <br />
             {details.address2}
@@ -73,6 +80,17 @@ export default class InfoBox extends React.Component {
               <Icon icon="handicap" size="xsm" />
             </div>
           )}
+          <div className="feedback-section">
+            <a
+              className="mail"
+              href={`https://mail.google.com/mail/?view=cm&fs=1&tf=1&to=${
+                email.to
+              }&su=${email.subject}&body=${encodeURIComponent(email.body)}`}
+              target="_blank"
+              rel="noopener noreferrer">
+              Report Inactive
+            </a>
+          </div>
         </div>
       </div>
     );

--- a/src/renderer/containers/map/infoBox/index.jsx
+++ b/src/renderer/containers/map/infoBox/index.jsx
@@ -34,7 +34,7 @@ export default class InfoBox extends React.Component {
     )}+${details.zipCode}`;
     const email = {
       to: 'smartcolumbusos@columbus.gov',
-      subject: 'Service location No Longer Active',
+      subject: 'Service Location No Longer Active',
       body: `The following service area is no longer active.\n\n\t${
         details.name
       }\n\t${details.address1}\n\t${details.address2}\n\tPhone: ${

--- a/src/renderer/containers/map/infoBox/infoBox.scss
+++ b/src/renderer/containers/map/infoBox/infoBox.scss
@@ -31,13 +31,13 @@
 
 .handicap-section {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
 }
 
 .feedback-section {
   display: flex;
   font-weight: bold;
-  justify-content: start;
+  justify-content: flex-start;
   a {
     color: white;
     text-decoration: none;

--- a/src/renderer/containers/map/infoBox/infoBox.scss
+++ b/src/renderer/containers/map/infoBox/infoBox.scss
@@ -34,6 +34,19 @@
   justify-content: end;
 }
 
+.feedback-section {
+  display: flex;
+  font-weight: bold;
+  justify-content: start;
+  a {
+    color: white;
+    text-decoration: none;
+    &:visited {
+      color: white;
+    }
+  }
+}
+
 .number {
   color: #fff500;
   display: block;


### PR DESCRIPTION
This allows the user a way to report when a service is no longer active.
Clicking the link in the UI will auto generate an email to the SCOSE team and notify them that the location is no longer in service.

This will create an email coming from the users gmail account. This will allow the SCOSE to be in direct contact with the users reporting it and not have the application be the middleman. 

NOTE: this will not remove the service from the UI. Did not add that capability because it would mean that the application is responsible for maintaining a list of inactive services.. We should not be managing the data from the SCOSE. It is best if the SCOSE data is updated and maintained.


**Issue Addressed**
#30 

**UI**
<img width="834" alt="Service_Locator" src="https://user-images.githubusercontent.com/2163914/64082677-9cfbd080-cce0-11e9-9dcb-ccead4427bf8.png">

**Generated Email content**
<img width="1201" alt="Compose_Mail_-_mihiramin89_gmail_com_-_Gmail" src="https://user-images.githubusercontent.com/2163914/64082669-7b9ae480-cce0-11e9-999e-4c378b4e0a4c.png">
