### PR TITLE
Correctly use .env file to load environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 3. clone the code base
 4. run the following command `npm i` - installs all node dependencies
 5. follow the instructions [here](https://developers.google.com/maps/gmp-get-started#quickstart) to set up a new Google Maps project, including creating an API key
-6. add the API key as an environment variable: `export MAP_KEY=[your-api-key]`
+6. create a file `.env` and add a line with your API key from Google as: `MAP_KEY=[your-api-key-here]`
 7. to start locally run the following command `npm run dev`
 8. navigate to [localhost:3000](http://localhost:3000/)
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "copy-webpack-plugin": "^5.0.0",
     "cross-env": "^5.2.0",
     "css-loader": "^2.0.2",
+    "dotenv": "^8.1.0",
     "dotenv-webpack": "^1.5.7",
     "eslint": "^5.10.0",
     "eslint-config-airbnb": "^17.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,15 @@ const path = require('path');
 const webpack = require('webpack');
 
 const Dotenv = require('dotenv-webpack');
+const dotenv = require('dotenv');
 const CopyPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const DEFAULT_PORT = process.env.PORT || 3000;
 const HOST = process.env.HOST || 'localhost';
 const PROTOCOL = process.env.HTTPS === 'true' ? 'https' : 'http';
+
+dotenv.config();
 
 // I am hoping these get cleaned up for webpack 4
 // or is no longer needed for a css chunk in the future of webpack


### PR DESCRIPTION
This was not working as intended, I have added the `dotenv` package to load the `.env` file and store in the `process.env` object so each developer can have their own environment variables.