### PR TITLE
Wrap text on home page buttons

### DIFF
--- a/src/renderer/scenes/chooseCategory/chooseCategoryClass.jsx
+++ b/src/renderer/scenes/chooseCategory/chooseCategoryClass.jsx
@@ -35,7 +35,7 @@ export default class ChooseCategory extends React.Component {
               key={`cat${id}`}
               onClick={() => this.chooseCategory(id)}
               raised
-              className="jumbo bg-primary text-white mb30">
+              className="jumbo bg-primary text-white wrap-lines mb30">
               {CATEGORY_LABELS[id]}
             </Button>
           ))}


### PR DESCRIPTION
[https://github.com/SCODEMeetup/community-services-locator-ui/issues/71](url)

Wrapping text so buttons are visible on mobile devices

<img width="361" alt="Screen Shot 2020-03-26 at 8 28 43 PM" src="https://user-images.githubusercontent.com/19788219/77709156-8b418980-6fa0-11ea-9c5e-e75ad3bc3f57.png">
