### PR TITLE
#73 Remove appending services As Text In First Category

### DIFF
--- a/src/renderer/components/appBar/appBarClass.jsx
+++ b/src/renderer/components/appBar/appBarClass.jsx
@@ -50,7 +50,7 @@ export default class CustomAppBar extends React.Component {
           getServiceChildren(openCategory);
           openDrawer();
         }}>
-        CHOOSE {CATEGORY_LABELS[openCategory].toUpperCase()} SERVICES
+        CHOOSE {CATEGORY_LABELS[openCategory].topBar}
         {selectedServices[openCategory] && Object.keys(selectedServices[openCategory]).length > 0
           ? ` (${Object.keys(selectedServices[openCategory]).length})`
           : null}

--- a/src/renderer/redux/modules/services/constants.js
+++ b/src/renderer/redux/modules/services/constants.js
@@ -4,11 +4,11 @@ export const API_URL = API_BASE + API_PREFIX;
 
 // This is all categories in our current dataset
 export const CATEGORY_LABELS = {
-  566: 'Housing and Utility Assistance',
-  565: 'Health Care',
+  566: {name: 'Housing and Utility Assistance', topBar: 'HOUSING AND UTILITY ASSISTANCE SERVICES'},
+  565: {name: 'Health Care Services', topBar: 'HEATH CARE SERVICES'},
   // 561: 'Where to Donate',
   // 832: 'Advocacy, Planning and Professional Development',
-  563: 'Emergency Food, Clothing, Furniture and Disaster Services',
+  563: {name: 'Emergency Food, Clothing, Furniture and Disaster Services', topBar: 'EMERGENCY FOOD, CLOTHING, FURNITURE AND DISASTER SERVICES'}
   // 562: 'Arts, Education, Employment and Income Support',
   // 560: 'Adult Care and Youth Programs',
   // 568: 'Mental Health and Counseling Resources',

--- a/src/renderer/scenes/chooseCategory/chooseCategoryClass.jsx
+++ b/src/renderer/scenes/chooseCategory/chooseCategoryClass.jsx
@@ -36,7 +36,7 @@ export default class ChooseCategory extends React.Component {
               onClick={() => this.chooseCategory(id)}
               raised
               className="jumbo bg-primary text-white wrap-lines mb30">
-              {CATEGORY_LABELS[id]}
+              {CATEGORY_LABELS[id].name}
             </Button>
           ))}
         </div>

--- a/src/renderer/scenes/chooseSubCategory/chooseSubCategoryClass.jsx
+++ b/src/renderer/scenes/chooseSubCategory/chooseSubCategoryClass.jsx
@@ -99,7 +99,7 @@ export default class ChooseCategory extends React.Component {
     const id = this.props.openCategory;
 
     if (id && CATEGORY_LABELS[id]) {
-      return CATEGORY_LABELS[id];
+      return CATEGORY_LABELS[id].name;
     }
 
     return '';


### PR DESCRIPTION
To solve the issue reported in #73 I updated the constants file to have the message we want in the name and the "app bar". 

My thought process was that since we are already maintaining a list of each of their names it would be easier to have a specific message for the "app bar" associated with each one rather than trying to make a few generic ones for each circumstance, especially due to the commented out options (that may be coming at some point?) looking like they might have more specific app bar messages.
<img width="1165" alt="Screen Shot 2020-03-29 at 9 32 04 AM" src="https://user-images.githubusercontent.com/36570944/77850483-d3c79580-71a0-11ea-8368-73f968c590d6.png">


