### PR TITLE
Small UI fixes

### DIFF
--- a/src/renderer/redux/modules/services/constants.js
+++ b/src/renderer/redux/modules/services/constants.js
@@ -4,11 +4,17 @@ export const API_URL = API_BASE + API_PREFIX;
 
 // This is all categories in our current dataset
 export const CATEGORY_LABELS = {
-  566: {name: 'Housing and Utility Assistance', topBar: 'HOUSING AND UTILITY ASSISTANCE SERVICES'},
-  565: {name: 'Health Care Services', topBar: 'HEATH CARE SERVICES'},
+  566: {
+    name: 'Housing and Utility Assistance',
+    topBar: 'HOUSING AND UTILITY ASSISTANCE SERVICES',
+  },
+  565: { name: 'Health Care Services', topBar: 'HEALTH CARE SERVICES' },
   // 561: 'Where to Donate',
   // 832: 'Advocacy, Planning and Professional Development',
-  563: {name: 'Emergency Food, Clothing, Furniture and Disaster Services', topBar: 'EMERGENCY FOOD, CLOTHING, FURNITURE AND DISASTER SERVICES'}
+  563: {
+    name: 'Emergency Food, Clothing, Furniture and Disaster Services',
+    topBar: 'EMERGENCY FOOD, CLOTHING, FURNITURE AND DISASTER SERVICES',
+  },
   // 562: 'Arts, Education, Employment and Income Support',
   // 560: 'Adult Care and Youth Programs',
   // 568: 'Mental Health and Counseling Resources',

--- a/src/renderer/scenes/chooseCategory/chooseCategoryClass.jsx
+++ b/src/renderer/scenes/chooseCategory/chooseCategoryClass.jsx
@@ -26,9 +26,7 @@ export default class ChooseCategory extends React.Component {
   render() {
     return (
       <div className="choose-category layout-padding bg-black text-white flex flex-center column">
-        <h1 className="text-center">
-          Hi there! What can I help you find today?
-        </h1>
+        <h1 className="text-center">What can we help you find today?</h1>
         <div className="flex column no-wrap">
           {Object.keys(CATEGORY_LABELS).map(id => (
             <Button

--- a/src/renderer/scenes/chooseSubCategory/chooseSubCategoryClass.jsx
+++ b/src/renderer/scenes/chooseSubCategory/chooseSubCategoryClass.jsx
@@ -88,13 +88,6 @@ export default class ChooseCategory extends React.Component {
     });
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  positivePhrase() {
-    const phrases = ['Ok!', 'Awesome!', 'Great!', 'Alrighty!', 'Sweet!'];
-
-    return phrases[randomNumberBetween(0, phrases.length - 1)];
-  }
-
   categoryName() {
     const id = this.props.openCategory;
 
@@ -102,7 +95,7 @@ export default class ChooseCategory extends React.Component {
       return CATEGORY_LABELS[id].name;
     }
 
-    return '';
+    return 'services';
   }
 
   _renderMoreButton() {
@@ -123,7 +116,7 @@ export default class ChooseCategory extends React.Component {
     return (
       <div className="choose-sub-category layout-padding bg-black text-white flex flex-center column">
         <h1 className="text-center">
-          {`${this.positivePhrase()} What type of ${this.categoryName()} would you like to find?`}
+          {`What type of ${this.categoryName()} would you like to find?`}
         </h1>
         <div className="flex column no-wrap">
           {this.subCategories().map(cat => (


### PR DESCRIPTION
Relates to #76, #77, #64 

- Change the verbiage to be less 'friendly'. 
- Fix a typo: "Heath" -> "Health"
- Add a placeholder value so the header while loading subcategories is a complete sentence: "What type of *services* would you like to find?"