### PR TITLE
fix style

### DIFF
--- a/src/renderer/components/appBar/appBar.scss
+++ b/src/renderer/components/appBar/appBar.scss
@@ -24,7 +24,7 @@
     display: contents;
   }
   .power {
-    align-items: end;
+    align-items: flex-end;
     color: #e0e0e0;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Fix the disclaimer alignment for all browsers. 

align-items: flex-end makes the text align all the way to the right in all browsers (firefox, safari, chrome). "end" only does it for firefox.