### PR TITLE
decorated mapbox with FreshTrak links

### DIFF
--- a/src/renderer/containers/map/infoBox/index.jsx
+++ b/src/renderer/containers/map/infoBox/index.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-comment-textnodes */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isNil, replace } from 'ramda';
@@ -85,8 +84,7 @@ export default class InfoBox extends React.Component {
               <p>
                 <a
                   href={details.freshtrakData.agencyURL + FRESHTRAK_UTM_PARAMS}
-                  className="number"
-                  // eslint-disable-next-line react/jsx-no-target-blank
+                  className="freshtrak-link"
                   target="_blank"
                   rel="noopener noreferrer">
                   Resource Events for {details.freshtrakData.agencyName}
@@ -100,7 +98,7 @@ export default class InfoBox extends React.Component {
               <p>
                 <a
                   href={details.freshtrakData.zipURL + FRESHTRAK_UTM_PARAMS}
-                  className="number"
+                  className="freshtrak-link"
                   target="_blank"
                   rel="noopener noreferrer">
                   Resource Events for Zip Code {details.zipCode}

--- a/src/renderer/containers/map/infoBox/index.jsx
+++ b/src/renderer/containers/map/infoBox/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-comment-textnodes */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isNil, replace } from 'ramda';
@@ -6,6 +7,7 @@ import Icon from 'components/icon';
 import './infoBox.scss';
 
 export default class InfoBox extends React.Component {
+  // eslint-disable-next-line react/sort-comp
   static defaultProps = {
     details: {
       id: 'dummyID',
@@ -16,6 +18,7 @@ export default class InfoBox extends React.Component {
       phones: [],
       handicapAccessFlag: 'Y',
       hours: '24 hours Mon-Sun HandsOn Information and Referral Hotline',
+      freshtrakData: '',
     },
   };
 
@@ -26,6 +29,7 @@ export default class InfoBox extends React.Component {
 
   render() {
     const { details } = this.props;
+    console.log(`details: ${details}`);
     const conversion = addr => replace(/ /g, '+', addr);
     const address = `https://www.google.com/maps/place/${conversion(
       details.address1
@@ -42,11 +46,17 @@ export default class InfoBox extends React.Component {
         ', '
       )}\n\nDataset: https://discovery.smartcolumbusos.com/dataset/handson_central_ohio/community_services_agencies`,
     };
+    const FRESHTRAK_UTM_PARAMS =
+      '?utm_source=cbus_helper&utm_campaign=freshtrak_events';
     return (
       <div className="info-box">
         <div className="content">
           <h2>{details.name}</h2>
-          <a href={address} className="address" target="_blank">
+          <a
+            href={address}
+            className="address"
+            target="_blank"
+            rel="noopener noreferrer">
             {details.address1}
             <br />
             {details.address2}
@@ -63,6 +73,41 @@ export default class InfoBox extends React.Component {
               <hr />
               <h3>Hours</h3>
               <p>{details.hours}</p>
+            </div>
+          )}
+          {!isNil(details.freshtrakData) && (
+            <div>
+              <hr />
+              <h3>FreshTrak Food Resource Events</h3>
+            </div>
+          )}
+          {!isNil(details.freshtrakData) && !!details.freshtrakData.agencyURL && (
+            <div>
+              <p>
+                <a
+                  href={details.freshtrakData.agencyURL + FRESHTRAK_UTM_PARAMS}
+                  className="number"
+                  // eslint-disable-next-line react/jsx-no-target-blank
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  Resource Events for {details.freshtrakData.agencyName}
+                </a>
+              </p>
+            </div>
+          )}
+
+          {!isNil(details.freshtrakData) && (
+            <div>
+              <p>
+                <a
+                  href={details.freshtrakData.zipURL + FRESHTRAK_UTM_PARAMS}
+                  className="number"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  Resource Events for Zip Code {details.zipCode}
+                </a>
+                <br />
+              </p>
             </div>
           )}
           {!isNil(details.services) && (

--- a/src/renderer/containers/map/infoBox/index.jsx
+++ b/src/renderer/containers/map/infoBox/index.jsx
@@ -29,7 +29,6 @@ export default class InfoBox extends React.Component {
 
   render() {
     const { details } = this.props;
-    console.log(`details: ${details}`);
     const conversion = addr => replace(/ /g, '+', addr);
     const address = `https://www.google.com/maps/place/${conversion(
       details.address1

--- a/src/renderer/containers/map/infoBox/infoBox.scss
+++ b/src/renderer/containers/map/infoBox/infoBox.scss
@@ -63,3 +63,11 @@
   text-align: center;
   padding-bottom: 2%;
 }
+
+.freshtrak-link {
+  color: #fff500;
+  display: block;
+  font-size: 0.8rem;
+  text-align: center;
+  padding-bottom: 2%;
+}


### PR DESCRIPTION
Part of a POC for integration with the Mid-Ohio Food Bank [FreshTrak application](https://beta.freshtrak.com/).  Added FreshTrak links to Emergency Food mapbox when there is a match.  See [mofb-api PR #91](https://github.com/SCODEMeetup/mofb-api/pull/91) for details.

Example mapbox when there is a match with a FreshTrak agency id.:

 
<img width="320" alt="Screen Shot 2020-10-21 at 5 39 47 PM" src="https://user-images.githubusercontent.com/31697968/96790840-6b9f0200-13c5-11eb-8d8b-8df74e0dcdf1.png">

[FreshTrak Agency Link](https://beta.freshtrak.com/agency/events/6?utm_source=cbus_helper&utm_campaign=freshtrak_events)
[FreshTrak Zip Code Link](https://beta.freshtrak.com/events/list/43123?utm_source=cbus_helper&utm_campaign=freshtrak_events)

Example mapbox when there is no match with a FreshTrak agency id.

<img width="320" alt="Screen Shot 2020-10-21 at 5 50 04 PM" src="https://user-images.githubusercontent.com/31697968/96791287-2a5b2200-13c6-11eb-8c64-a70eb0e7d0e8.png">

